### PR TITLE
Update owasp.yml

### DIFF
--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -1,8 +1,9 @@
 name: OWASP PR Scanner
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
+
 
 permissions:
   contents: read


### PR DESCRIPTION
I’ve updated the workflow trigger to pull_request_target so that the GitHub Actions bot has the correct permissions to post scanner results back to the PR.

With pull_request, the workflow runs in the context of the contributor’s fork, which restricts the default GITHUB_TOKEN to read-only. That’s why our OWASP scanner step was failing with a 403 error when trying to create comments.

Using pull_request_target makes the workflow execute in the base repo context, giving it issues: write and pull-requests: write permissions so it can safely create or update comments on the PR.